### PR TITLE
Add PySide6 desktop UI and offline assistant pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,40 @@
 # Mira Assistant
 
-Windows odaklı, Türkçe destekli kişisel asistanın MVP kaynak kodu.
+Windows odaklı, Türkçe destekli kişisel asistanın masaüstü MVP sürümü.
+
+## Özellikler
+
+- PySide6 tabanlı masaüstü arayüz: komut girişi, ajanda ve görev panelleri.
+- STT için `faster-whisper` + `sounddevice` + `webrtcvad`.
+- TTS için `edge-tts` öncelikli, `pyttsx3` yedek.
+- SQLite + SQLModel veri katmanı, tüm tarih/saat değerleri UTC olarak saklanır.
+- Belge ingest akışı (PDF/DOCX/PPTX/TXT/IMG) → chunk → embedding → Chroma vektör deposu.
+- RAG tabanlı konu özetleri ve basit kural temelli uyarılar.
 
 ## Kurulum
 
 ```powershell
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
+py -3.11 -m venv venv
+./venv/Scripts/Activate.ps1
 pip install -r requirements.txt
-python app.py init-db
 ```
 
-## Çalıştırma
+OCR için sistemde Tesseract kurulumu gerekir:
 
 ```powershell
-python app.py process "22'si 10:00 toplantı"
+winget install tesseract --source winget
 ```
 
-## Test
+## İlk Çalıştırma
 
 ```powershell
-pytest
+python .\app_ui.py
 ```
 
-## Not
+İlk açılışta `~/MiraData/` altında gerekli klasörler, `db/mira.sqlite` veritabanı ve `index/` vektör deposu oluşturulur.
 
-- Sesli özellikler için `faster-whisper` ve `edge-tts` entegrasyonu TODO.
-- Tray arayüzü için `pystray` entegrasyonu TODO.
+## Notlar
+
+- Uygulama çevrimdışı çalışacak şekilde tasarlanmıştır; dış API çağrısı yapılmaz.
+- Ses ve bildirim özellikleri Windows ortamında test edilmelidir.
+- Inbox klasörüne bırakılan belgeler UI üzerinden ingest edilerek arşivlenir.

--- a/app_ui.py
+++ b/app_ui.py
@@ -1,0 +1,54 @@
+"""Entry point for the Mira Assistant desktop application."""
+from __future__ import annotations
+
+import logging
+import sys
+
+from PySide6.QtCore import QMetaObject, Qt
+from PySide6.QtWidgets import QApplication
+from sqlmodel import select
+
+from config import settings
+from mira_assistant.core.storage import Event, get_session
+from mira_assistant.ui.main_window import MainWindow
+from mira_assistant.ui.tray import TrayController
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    handlers=[logging.FileHandler(str(settings.log_dir / "mira.log")), logging.StreamHandler(sys.stdout)],
+)
+
+
+def create_app() -> tuple[QApplication, MainWindow, TrayController]:
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    scheduler = window.dispatcher.scheduler
+    scheduler.start()
+    with get_session() as session:
+        events = list(session.exec(select(Event)))
+    scheduler.restore_jobs_from_db(events)
+    def invoke(name: str):
+        return lambda: QMetaObject.invokeMethod(window, name, Qt.QueuedConnection)
+
+    quit_app = lambda: QMetaObject.invokeMethod(app, "quit", Qt.QueuedConnection)
+    tray = TrayController(
+        on_toggle_listen=invoke("_toggle_listening"),
+        on_show_agenda=invoke("refresh_events"),
+        on_quick_note=invoke("quick_note"),
+        on_quit=quit_app,
+    )
+    tray.start()
+    return app, window, tray
+
+
+def main() -> None:
+    app, window, tray = create_app()
+    window.show()
+    exit_code = app.exec()
+    tray.stop()
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/mira_assistant/core/actions.py
+++ b/mira_assistant/core/actions.py
@@ -1,0 +1,227 @@
+"""Action dispatcher turning intents into database operations."""
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from sqlmodel import Session, select
+
+from .advisor import collect_daily_warnings, detect_conflicts
+from .intent import Action
+from .scheduler import ReminderScheduler
+from .storage import (
+    Chunk,
+    Document,
+    Event,
+    Task,
+    TaskStatus,
+    add_event,
+    complete_task,
+    delete_event,
+    get_session,
+    init_db,
+    list_events_between,
+    list_tasks,
+    upsert_task,
+)
+from .summarizer import generate_summary
+from .vector_store import VectorStore
+from ..io.ingest import DocumentIngestor
+
+
+@dataclass
+class ActionResult:
+    intent: str
+    data: Dict[str, Any]
+
+
+class ActionDispatcher:
+    """Coordinate storage, scheduler and ingest subsystems."""
+
+    def __init__(self, *, scheduler: Optional[ReminderScheduler] = None, vector_store: Optional[VectorStore] = None) -> None:
+        self.scheduler = scheduler or ReminderScheduler()
+        self.vector_store = vector_store or VectorStore()
+        self.ingestor = DocumentIngestor(vector_store=self.vector_store)
+        init_db()
+
+    def run(self, action: Action) -> ActionResult:
+        handler = getattr(self, f"handle_{action.intent}", None)
+        if handler is None:
+            raise NotImplementedError(f"Intent {action.intent} is not supported")
+        data = handler(action.payload)
+        return ActionResult(intent=action.intent, data=data)
+
+    # Event handlers
+    def handle_add_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        start = _parse_iso(payload.get("start"))
+        end = _parse_iso(payload.get("end"))
+        event = Event(
+            title=payload.get("title", "Etkinlik"),
+            start_dt=start or dt.datetime.now(dt.timezone.utc),
+            end_dt=end,
+            location=payload.get("location"),
+            remind_policy=payload.get("remind_policy"),
+            participants=payload.get("participants"),
+            link=payload.get("link"),
+            notes=payload.get("notes"),
+        )
+        with get_session() as session:
+            event = add_event(session, event)
+            warnings = detect_conflicts(session, event)
+        jobs = self.scheduler.schedule_event_reminders(event, event.remind_policy)
+        return {"event_id": event.id, "warnings": warnings, "jobs": jobs}
+
+    def handle_update_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        event_id = int(payload.get("event_id", 0))
+        updates: Dict[str, Any] = {}
+        if "start" in payload:
+            updates["start_dt"] = _parse_iso(payload["start"])
+        if "end" in payload:
+            updates["end_dt"] = _parse_iso(payload["end"])
+        if "title" in payload:
+            updates["title"] = payload["title"]
+        with get_session() as session:
+            event = session.get(Event, event_id)
+            if event is None:
+                return {"updated": False}
+            for key, value in updates.items():
+                setattr(event, key, value)
+            session.add(event)
+            session.commit()
+            session.refresh(event)
+        self.scheduler.schedule_event_reminders(event, event.remind_policy)
+        if hasattr(event, "model_dump"):
+            payload = event.model_dump()  # type: ignore[attr-defined]
+        else:
+            payload = event.dict()
+        return {"updated": True, "event": payload}
+
+    def handle_delete_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        event_id = int(payload.get("event_id", 0))
+        with get_session() as session:
+            deleted = delete_event(session, event_id)
+        return {"deleted": deleted}
+
+    def handle_list_events(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        now = dt.datetime.now(dt.timezone.utc)
+        end = now + dt.timedelta(days=7)
+        with get_session() as session:
+            events = list_events_between(session, now, end)
+        return {
+            "events": [
+                {
+                    "id": event.id,
+                    "title": event.title,
+                    "start_dt": event.start_dt.isoformat(),
+                    "end_dt": event.end_dt.isoformat() if event.end_dt else None,
+                    "location": event.location,
+                }
+                for event in events
+            ]
+        }
+
+    # Task handlers
+    def handle_add_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        task = Task(
+            title=payload.get("title", "Görev"),
+            due_dt=_parse_iso(payload.get("due")),
+            priority=payload.get("priority", 0),
+            tags=payload.get("tags"),
+            notes=payload.get("notes"),
+        )
+        with get_session() as session:
+            task = upsert_task(session, task)
+        return {"task_id": task.id}
+
+    def handle_update_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        task_id = int(payload.get("task_id", 0))
+        with get_session() as session:
+            task = session.get(Task, task_id)
+            if task is None:
+                return {"updated": False}
+            if "title" in payload:
+                task.title = payload["title"]
+            if "due" in payload:
+                task.due_dt = _parse_iso(payload["due"])
+            if "status" in payload:
+                task.status = TaskStatus(payload["status"])
+            session.add(task)
+            session.commit()
+            session.refresh(task)
+        if hasattr(task, "model_dump"):
+            payload = task.model_dump()  # type: ignore[attr-defined]
+        else:
+            payload = task.dict()
+        return {"updated": True, "task": payload}
+
+    def handle_complete_task(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        task_id = int(payload.get("task_id", 0))
+        with get_session() as session:
+            task = complete_task(session, task_id)
+        return {"completed": task is not None}
+
+    def handle_list_tasks(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        include_completed = payload.get("include_completed", False)
+        with get_session() as session:
+            tasks = list_tasks(session, include_completed=include_completed)
+        return {
+            "tasks": [
+                {
+                    "id": task.id,
+                    "title": task.title,
+                    "due_dt": task.due_dt.isoformat() if task.due_dt else None,
+                    "status": task.status.value,
+                }
+                for task in tasks
+            ]
+        }
+
+    # Reminder handler
+    def handle_schedule_reminder(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        remind_at = _parse_iso(payload.get("remind_at"))
+        title = payload.get("message", "Hatırlatma")
+        event = Event(title=title, start_dt=remind_at or dt.datetime.now(dt.timezone.utc))
+        event.id = -1
+        jobs = self.scheduler.schedule_event_reminders(event, [0])
+        return {"jobs": jobs}
+
+    # Ingest & summary
+    def handle_ingest_docs(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        topic = payload.get("topic") or "Genel"
+        processed = self.ingestor.process_inbox(topic)
+        return {"ingested": processed}
+
+    def handle_summarize_topic(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        topic = payload["topic"]
+        with get_session() as session:
+            document_stmt = select(Document).where(Document.topic == topic).order_by(Document.ingested_at.desc())
+            documents = list(session.exec(document_stmt))
+            chunks: list[str] = []
+            for document in documents:
+                chunk_stmt = select(Chunk).where(Chunk.doc_id == document.id).order_by(Chunk.seq)
+                chunks.extend(chunk.text for chunk in session.exec(chunk_stmt))
+        summary = generate_summary(topic, chunks)
+        return {"topic": topic, "summary": summary}
+
+    def handle_advise_on_topic(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        with get_session() as session:
+            warnings = collect_daily_warnings(session)
+        return {"warnings": warnings}
+
+
+def _parse_iso(value: Any) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    if isinstance(value, dt.datetime):
+        return value if value.tzinfo else value.replace(tzinfo=dt.timezone.utc)
+    try:
+        parsed = dt.datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed
+
+
+__all__ = ["ActionDispatcher", "ActionResult"]

--- a/mira_assistant/core/advisor.py
+++ b/mira_assistant/core/advisor.py
@@ -1,28 +1,67 @@
-"""Advisor utilities for conflict detection and suggestions."""
+"""Rule based advisor warnings for the assistant UI."""
 from __future__ import annotations
 
 import datetime as dt
 from typing import List
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
-from .storage import Event, fetch_events_between
+from .storage import Document, Event, list_due_tasks
 
 
 def detect_conflicts(session: Session, candidate: Event) -> List[str]:
     """Return textual warnings for overlapping events."""
+
     if candidate.start_dt is None:
         return []
+    start = candidate.start_dt
     end = candidate.end_dt or (candidate.start_dt + dt.timedelta(hours=1))
-    overlapping = fetch_events_between(session, candidate.start_dt, end)
-    conflicts = []
-    for event in overlapping:
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=dt.timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=dt.timezone.utc)
+    statement = select(Event).where(Event.start_dt < end, Event.end_dt.is_(None) | (Event.end_dt > start))
+    warnings: List[str] = []
+    for event in session.exec(statement):
         if event.id == candidate.id:
             continue
-        conflicts.append(
-            f"Çakışma: '{event.title}' etkinliği {event.start_dt.isoformat()} zamanında zaten planlı."
+        warnings.append(
+            f"Çakışma: '{event.title}' etkinliği {event.start_dt.astimezone(dt.timezone.utc).isoformat()} zamanında."  # noqa: E501
         )
-    return conflicts
+    return warnings
 
 
-__all__ = ["detect_conflicts"]
+def overdue_task_warnings(session: Session, reference: dt.datetime | None = None) -> List[str]:
+    reference = reference or dt.datetime.now(dt.timezone.utc)
+    tasks = list_due_tasks(session, reference)
+    return [f"Geciken görev: {task.title} (son tarih {task.due_dt})" for task in tasks]
+
+
+def topic_update_warnings(session: Session, horizon_hours: int = 24) -> List[str]:
+    now = dt.datetime.now(dt.timezone.utc)
+    horizon = now + dt.timedelta(hours=horizon_hours)
+    statement = select(Event).where(Event.start_dt >= now, Event.start_dt <= horizon)
+    warnings: List[str] = []
+    for event in session.exec(statement):
+        topic = event.title.split()[0]
+        doc_stmt = select(Document).where(
+            Document.topic == topic,
+            Document.ingested_at >= now - dt.timedelta(days=7),
+        )
+        if session.exec(doc_stmt).first() is None:
+            warnings.append(f"'{event.title}' toplantısı öncesi ilgili belgeler 7 gündür güncellenmedi.")
+    return warnings
+
+
+def collect_daily_warnings(session: Session) -> List[str]:
+    warnings = overdue_task_warnings(session)
+    warnings.extend(topic_update_warnings(session))
+    return warnings
+
+
+__all__ = [
+    "detect_conflicts",
+    "overdue_task_warnings",
+    "topic_update_warnings",
+    "collect_daily_warnings",
+]

--- a/mira_assistant/core/parser_tr.py
+++ b/mira_assistant/core/parser_tr.py
@@ -1,30 +1,58 @@
-"""Turkish language parsing helpers."""
+"""Turkish natural language datetime parsing helpers."""
 from __future__ import annotations
 
 import datetime as dt
+import re
 from typing import Optional
 
 import dateparser
+
+from config import settings
 
 
 DEFAULT_SETTINGS = {
     "DATE_ORDER": "DMY",
     "PREFER_DATES_FROM": "future",
-    "TIMEZONE": "Europe/Istanbul",
+    "TIMEZONE": settings.timezone_name,
     "RETURN_AS_TIMEZONE_AWARE": True,
     "PARSERS": ["relative-time", "custom-formats", "absolute-time"],
 }
 
+_TIME_PATTERN = re.compile(r"(\d{1,2}[:. ]\d{2})|(saat\s*\d{1,2})", re.IGNORECASE)
 
-def parse_datetime(text: str, reference: Optional[dt.datetime] = None) -> Optional[dt.datetime]:
-    """Parse Turkish natural language datetime expressions."""
-    settings = DEFAULT_SETTINGS.copy()
+
+def parse_datetime(
+    text: str,
+    *,
+    reference: Optional[dt.datetime] = None,
+    default_hour: Optional[int] = None,
+    default_minute: int = 0,
+) -> Optional[dt.datetime]:
+    """Parse a Turkish datetime expression and return a timezone aware value."""
+
+    settings_dict = DEFAULT_SETTINGS.copy()
     if reference is not None:
-        settings["RELATIVE_BASE"] = reference
-    result = dateparser.parse(text, languages=["tr"], settings=settings)
-    if isinstance(result, dt.datetime):
-        return result
-    return None
+        settings_dict["RELATIVE_BASE"] = reference
+    parsed = dateparser.parse(text, languages=["tr"], settings=settings_dict)
+    if not isinstance(parsed, dt.datetime):
+        return None
+    if default_hour is not None and not _has_explicit_time(text):
+        parsed = parsed.replace(hour=default_hour, minute=default_minute, second=0, microsecond=0)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=settings.timezone)
+    return parsed
 
 
-__all__ = ["parse_datetime"]
+def to_utc(value: dt.datetime) -> dt.datetime:
+    """Convert a datetime to UTC ensuring timezone awareness."""
+
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=settings.timezone)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _has_explicit_time(text: str) -> bool:
+    return bool(_TIME_PATTERN.search(text))
+
+
+__all__ = ["parse_datetime", "to_utc"]

--- a/mira_assistant/core/storage.py
+++ b/mira_assistant/core/storage.py
@@ -1,15 +1,27 @@
-"""Data access layer built on top of SQLModel."""
+"""SQLite persistence layer built with SQLModel."""
 from __future__ import annotations
 
 import datetime as dt
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
-from sqlmodel import Field, SQLModel, Session, create_engine, select
-from sqlalchemy import Column, JSON, LargeBinary
+from sqlalchemy import Column, DateTime, JSON, LargeBinary
+from sqlmodel import Field, Session, SQLModel, create_engine, select
 
 from config import settings
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _ensure_utc(value: Optional[dt.datetime]) -> Optional[dt.datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
 
 
 class TaskStatus(str, Enum):
@@ -22,26 +34,25 @@ class Task(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     title: str
     status: TaskStatus = Field(default=TaskStatus.TODO)
-    due_dt: Optional[dt.datetime] = Field(default=None, sa_column_kwargs={"nullable": True})
-    priority: int = Field(default=0, ge=0, le=3)
-    tags: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
+    due_dt: Optional[dt.datetime] = Field(default=None, sa_column=Column(DateTime(timezone=True)))
+    priority: int = Field(default=0)
+    tags: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
     notes: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
-    source: str = Field(default="text")
-    created_at: dt.datetime = Field(default_factory=lambda: dt.datetime.utcnow())
-    updated_at: dt.datetime = Field(default_factory=lambda: dt.datetime.utcnow())
+    created_at: dt.datetime = Field(default_factory=_utcnow, sa_column=Column(DateTime(timezone=True)))
+    updated_at: dt.datetime = Field(default_factory=_utcnow, sa_column=Column(DateTime(timezone=True)))
 
 
 class Event(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     title: str
-    start_dt: dt.datetime
-    end_dt: Optional[dt.datetime] = Field(default=None, sa_column_kwargs={"nullable": True})
+    start_dt: dt.datetime = Field(sa_column=Column(DateTime(timezone=True)))
+    end_dt: Optional[dt.datetime] = Field(default=None, sa_column=Column(DateTime(timezone=True)))
     location: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
     remind_policy: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
     participants: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
     link: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
     notes: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
-    created_at: dt.datetime = Field(default_factory=lambda: dt.datetime.utcnow())
+    created_at: dt.datetime = Field(default_factory=_utcnow, sa_column=Column(DateTime(timezone=True)))
 
 
 class Document(SQLModel, table=True):
@@ -50,7 +61,7 @@ class Document(SQLModel, table=True):
     title: str
     topic: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
     tags: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
-    ingested_at: dt.datetime = Field(default_factory=lambda: dt.datetime.utcnow())
+    ingested_at: dt.datetime = Field(default_factory=_utcnow, sa_column=Column(DateTime(timezone=True)))
     checksum: str
     text_chars: Optional[int] = Field(default=None, sa_column_kwargs={"nullable": True})
     lang: Optional[str] = Field(default="tr", sa_column_kwargs={"nullable": True})
@@ -71,7 +82,7 @@ class Knowledge(SQLModel, table=True):
     fact: str
     confidence: float = Field(default=0.8)
     source: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
-    last_revalidated: Optional[dt.datetime] = Field(default=None, sa_column_kwargs={"nullable": True})
+    last_revalidated: Optional[dt.datetime] = Field(default=None, sa_column=Column(DateTime(timezone=True)))
 
 
 class Meeting(SQLModel, table=True):
@@ -82,92 +93,144 @@ class Meeting(SQLModel, table=True):
     summary_md: Optional[str] = Field(default=None, sa_column_kwargs={"nullable": True})
     action_items_json: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
     decisions_json: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
-    created_at: dt.datetime = Field(default_factory=lambda: dt.datetime.utcnow())
+    created_at: dt.datetime = Field(default_factory=_utcnow, sa_column=Column(DateTime(timezone=True)))
 
 
 _engine = None
 
 
 def get_engine(path: Optional[Path] = None):
-    """Return a singleton SQLAlchemy engine for the SQLite database."""
+    """Return a singleton SQLAlchemy engine for the configured SQLite database."""
+
     global _engine
     if _engine is None:
         settings.ensure_directories()
         db_path = path or settings.db_path
         _engine = create_engine(
-            f"sqlite:///{db_path}", echo=False, connect_args={"check_same_thread": False}
+            f"sqlite:///{db_path}",
+            echo=False,
+            connect_args={"check_same_thread": False},
         )
     return _engine
 
 
 def init_db(path: Optional[Path] = None) -> None:
-    """Create database tables according to the SQLModel metadata."""
+    """Create the database schema and ensure directories exist."""
+
+    settings.ensure_directories()
     engine = get_engine(path)
     SQLModel.metadata.create_all(engine)
 
 
 def get_session() -> Session:
-    """Return a session bound to the configured engine."""
-    engine = get_engine()
-    return Session(engine)
-
-
-def upsert_task(session: Session, task: Task) -> Task:
-    """Insert or update a task and maintain the updated timestamp."""
-    task.updated_at = dt.datetime.utcnow()
-    session.add(task)
-    session.commit()
-    session.refresh(task)
-    return task
+    return Session(get_engine())
 
 
 def add_event(session: Session, event: Event) -> Event:
-    """Persist an event to the database."""
+    event.start_dt = _ensure_utc(event.start_dt) or _utcnow()
+    event.end_dt = _ensure_utc(event.end_dt)
     session.add(event)
     session.commit()
     session.refresh(event)
     return event
 
 
-def list_due_tasks(session: Session, reference: Optional[dt.datetime] = None) -> List[Task]:
-    """Return tasks with due dates on or before the reference datetime."""
-    if reference is None:
-        reference = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
-    elif reference.tzinfo is None:
-        reference = reference.replace(tzinfo=dt.timezone.utc)
-    tasks = list(session.exec(select(Task)))
-    due_tasks: List[Task] = []
-    for task in tasks:
-        if task.due_dt is None:
-            continue
-        due_dt = task.due_dt
-        if due_dt.tzinfo is None:
-            due_dt = due_dt.replace(tzinfo=dt.timezone.utc)
-        if due_dt <= reference and task.status != TaskStatus.DONE:
-            due_tasks.append(task)
-    due_tasks.sort(key=lambda task: task.due_dt or dt.datetime.max)
-    return due_tasks
+def update_event(session: Session, event_id: int, updates: Dict[str, Any]) -> Optional[Event]:
+    event = session.get(Event, event_id)
+    if event is None:
+        return None
+    for key, value in updates.items():
+        if key in {"start_dt", "end_dt"} and isinstance(value, dt.datetime):
+            value = _ensure_utc(value)
+        setattr(event, key, value)
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+    return event
 
 
-def fetch_events_between(
-    session: Session, start: dt.datetime, end: dt.datetime
-) -> List[Event]:
-    statement = select(Event).where(Event.start_dt < end, (Event.end_dt.is_(None)) | (Event.end_dt > start))
+def delete_event(session: Session, event_id: int) -> bool:
+    event = session.get(Event, event_id)
+    if event is None:
+        return False
+    session.delete(event)
+    session.commit()
+    return True
+
+
+def upsert_task(session: Session, task: Task) -> Task:
+    task.updated_at = _utcnow()
+    task.due_dt = _ensure_utc(task.due_dt)
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+def complete_task(session: Session, task_id: int) -> Optional[Task]:
+    task = session.get(Task, task_id)
+    if task is None:
+        return None
+    task.status = TaskStatus.DONE
+    task.updated_at = _utcnow()
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+def list_events_between(session: Session, start: dt.datetime, end: dt.datetime) -> List[Event]:
+    start = _ensure_utc(start) or _utcnow()
+    end = _ensure_utc(end) or start
+    statement = select(Event).where(Event.start_dt >= start, Event.start_dt <= end).order_by(Event.start_dt)
     return list(session.exec(statement))
+
+
+def list_tasks(session: Session, *, include_completed: bool = False) -> List[Task]:
+    statement = select(Task)
+    if not include_completed:
+        statement = statement.where(Task.status != TaskStatus.DONE)
+    statement = statement.order_by(Task.due_dt.is_(None), Task.due_dt)
+    return list(session.exec(statement))
+
+
+def list_due_tasks(session: Session, reference: Optional[dt.datetime] = None) -> List[Task]:
+    reference = _ensure_utc(reference) or _utcnow()
+    statement = select(Task).where(Task.due_dt <= reference, Task.status != TaskStatus.DONE)
+    statement = statement.order_by(Task.due_dt)
+    return list(session.exec(statement))
+
+
+def get_document_by_checksum(session: Session, checksum: str) -> Optional[Document]:
+    statement = select(Document).where(Document.checksum == checksum)
+    return session.exec(statement).first()
+
+
+def bulk_insert_chunks(session: Session, document: Document, chunks: Sequence[Chunk]) -> None:
+    for chunk in chunks:
+        chunk.doc_id = document.id  # type: ignore[assignment]
+        session.add(chunk)
+    session.commit()
 
 
 __all__ = [
     "Task",
+    "TaskStatus",
     "Event",
     "Document",
     "Chunk",
     "Knowledge",
     "Meeting",
-    "TaskStatus",
     "init_db",
     "get_session",
     "add_event",
+    "update_event",
+    "delete_event",
     "upsert_task",
+    "complete_task",
+    "list_events_between",
+    "list_tasks",
     "list_due_tasks",
-    "fetch_events_between",
+    "get_document_by_checksum",
+    "bulk_insert_chunks",
 ]

--- a/mira_assistant/core/summarizer.py
+++ b/mira_assistant/core/summarizer.py
@@ -1,22 +1,71 @@
-"""Offline-first summariser implementation."""
+"""Offline summarisation helpers following the product template."""
 from __future__ import annotations
 
+import itertools
 import textwrap
-from typing import List, Sequence
+from typing import Iterable, List, Sequence
 
 
-def summarise_topic(chunks: Sequence[str]) -> str:
-    """Produce a simple bullet-point summary.
+def generate_summary(topic: str, chunks: Sequence[str], meeting_notes: Sequence[str] | None = None) -> str:
+    """Build a structured markdown summary for the requested topic."""
 
-    This placeholder implementation concatenates key sentences while leaving a
-    TODO for future LLM integration.
-    """
-    summary_lines: List[str] = ["- " + line.strip() for line in chunks if line.strip()]
-    summary = "\n".join(summary_lines[:8])
-    if not summary:
-        summary = "- TODO: Özet üretimi için içerik bulunamadı."
-    summary += "\n\nTODO: Gelişmiş özetleme için LLM entegrasyonu eklenecek."
-    return textwrap.dedent(summary).strip()
+    bullet_points = _collect_sentences(chunks, limit=8)
+    meeting_highlights = _collect_sentences(meeting_notes or [], limit=3)
+    summary = textwrap.dedent(
+        f"""
+        # {topic} Özeti
+
+        ## Özet
+        { _format_bullets(bullet_points, fallback="İlgili içerik bulunamadı.") }
+
+        ## Kararlar
+        { _format_bullets(meeting_highlights, fallback="Paylaşılan karar yok.") }
+
+        ## Aksiyonlar (Sahip/Tarih)
+        { _format_bullets(_infer_actions(bullet_points), fallback="Aksiyon ataması bulunamadı.") }
+
+        ## Riskler & Bağımlılıklar
+        { _format_bullets(_infer_risks(bullet_points), fallback="Belirgin risk yok.") }
+
+        ## Açık Sorular
+        { _format_bullets([], fallback="Takip gerektiren soru yok.") }
+        """
+    ).strip()
+    return "\n".join(line.rstrip() for line in summary.splitlines())
 
 
-__all__ = ["summarise_topic"]
+def _collect_sentences(texts: Iterable[str], *, limit: int) -> List[str]:
+    sentences: List[str] = []
+    for text in texts:
+        for sentence in itertools.chain.from_iterable(part.strip().split(". ") for part in text.split("\n")):
+            clean = sentence.strip().strip("-•")
+            if clean:
+                sentences.append(clean)
+            if len(sentences) >= limit:
+                return sentences[:limit]
+    return sentences[:limit]
+
+
+def _format_bullets(lines: Sequence[str], *, fallback: str) -> str:
+    if not lines:
+        return f"- {fallback}"
+    return "\n".join(f"- {line}" for line in lines)
+
+
+def _infer_actions(sentences: Sequence[str]) -> List[str]:
+    actions: List[str] = []
+    for sentence in sentences:
+        if any(keyword in sentence.lower() for keyword in ["yap", "hazırla", "gönder", "tamamla"]):
+            actions.append(sentence)
+    return actions
+
+
+def _infer_risks(sentences: Sequence[str]) -> List[str]:
+    risks: List[str] = []
+    for sentence in sentences:
+        if any(keyword in sentence.lower() for keyword in ["risk", "bekleniyor", "gecik", "kritik"]):
+            risks.append(sentence)
+    return risks
+
+
+__all__ = ["generate_summary"]

--- a/mira_assistant/io/ingest.py
+++ b/mira_assistant/io/ingest.py
@@ -1,4 +1,4 @@
-"""Document ingestion pipeline."""
+"""Document ingestion pipeline for offline processing."""
 from __future__ import annotations
 
 import datetime as dt
@@ -7,78 +7,129 @@ import logging
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Iterable, List, Optional, Sequence
+
+import numpy as np
 
 from config import settings
-from ..core.storage import Chunk, Document, get_session
-from ..core.vector_store import VectorStore
-from ..core.summarizer import summarise_topic
+from mira_assistant.core.summarizer import generate_summary
+from mira_assistant.core.vector_store import VectorStore
+from mira_assistant.core.storage import (
+    Chunk,
+    Document,
+    get_document_by_checksum,
+    get_session,
+)
 
 LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
 class IngestResult:
-    document: Document
+    document: Optional[Document]
     chunk_texts: List[str]
     summary: str
+    skipped: bool = False
 
 
 class DocumentIngestor:
-    """Handle moving files to the archive and updating metadata."""
+    """Process files from the inbox directory into the knowledge base."""
 
-    def __init__(self, vector_store: Optional[VectorStore] = None) -> None:
-        self._vector_store = vector_store or VectorStore()
+    def __init__(self, *, vector_store: Optional[VectorStore] = None, model_name: Optional[str] = None) -> None:
+        self.vector_store = vector_store or VectorStore()
+        self._model_name = model_name or settings.embed_model_name
+        self._model = None
 
-    def ingest(self, path: Path, topic: Optional[str] = None) -> IngestResult:
-        path = path.expanduser().resolve()
-        if not path.exists():
-            raise FileNotFoundError(path)
-        topic = topic or infer_topic_from_filename(path.name)
-        archive_path = build_archive_path(path, topic)
+    def process_inbox(self, default_topic: Optional[str] = None) -> List[str]:
+        processed: List[str] = []
+        for path in settings.inbox_path.iterdir():
+            if not path.is_file():
+                continue
+            try:
+                result = self.ingest(path, topic=default_topic)
+            except Exception as exc:  # pragma: no cover - ingestion robustness
+                LOGGER.error("Failed to ingest %s: %s", path, exc)
+                continue
+            if result and not result.skipped and result.document is not None:
+                processed.append(result.document.title)
+        return processed
+
+    def ingest(self, source_path: Path, topic: Optional[str] = None) -> IngestResult:
+        source_path = source_path.expanduser().resolve()
+        if not source_path.exists():
+            raise FileNotFoundError(source_path)
+        checksum = _sha256_of_path(source_path)
+        with get_session() as session:
+            existing = get_document_by_checksum(session, checksum)
+            if existing is not None:
+                LOGGER.info("Skipping %s; already ingested", source_path)
+                if hasattr(existing, "model_dump"):
+                    snapshot = Document.model_validate(existing, from_attributes=True)  # type: ignore[attr-defined]
+                else:
+                    snapshot = existing
+                return IngestResult(document=snapshot, chunk_texts=[], summary="", skipped=True)
+        topic = topic or infer_topic_from_filename(source_path.name)
+        archive_path = build_archive_path(source_path, topic)
         archive_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, archive_path)
+        shutil.move(str(source_path), archive_path)
         text = extract_text(archive_path)
-        checksum = sha256_of_path(archive_path)
-        chunk_texts: List[str] = []
+        chunk_texts = create_chunks(text)
+        embeddings = self._embed(chunk_texts)
+        tags = generate_tags(text)
+        summary = generate_summary(topic, chunk_texts)
         with get_session() as session:
             document = Document(
                 path=str(archive_path),
-                title=path.stem,
+                title=archive_path.stem,
                 topic=topic,
+                tags={"auto": tags},
                 checksum=checksum,
                 text_chars=len(text),
-                ingested_at=dt.datetime.utcnow(),
+                lang="tr",
+                ingested_at=dt.datetime.now(dt.timezone.utc),
             )
             session.add(document)
             session.commit()
             session.refresh(document)
-            chunks = create_chunks(document, text, session)
+            chunks = _create_chunk_models(document.id, chunk_texts, embeddings)
+            for chunk in chunks:
+                session.add(chunk)
             session.commit()
-            chunk_texts = [chunk.text for chunk in chunks]
-            document_snapshot = Document.model_validate(document, from_attributes=True)
-        summary = summarise_topic(chunk_texts)
-        self._vector_store.add_texts(
-            texts=chunk_texts,
-            metadatas=[{"doc_id": str(document_snapshot.id), "topic": document_snapshot.topic} for _ in chunk_texts],
-            ids=[f"doc-{document_snapshot.id}-chunk-{idx}" for idx, _ in enumerate(chunk_texts)],
-        )
-        return IngestResult(document=document_snapshot, chunk_texts=chunk_texts, summary=summary)
+        metadata = [{"doc_id": str(document.id), "topic": topic} for _ in chunk_texts]
+        ids = [f"doc-{document.id}-chunk-{idx}" for idx in range(len(chunk_texts))]
+        self.vector_store.add_embeddings(embeddings.tolist(), metadatas=metadata, ids=ids, documents=chunk_texts)
+        return IngestResult(document=document, chunk_texts=chunk_texts, summary=summary)
+
+    def _load_model(self):  # type: ignore[no-untyped-def]
+        if self._model is None:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+
+            self._model = SentenceTransformer(self._model_name)
+        return self._model
+
+    def _embed(self, texts: Sequence[str]) -> np.ndarray:
+        if not texts:
+            return np.zeros((0, 384), dtype=np.float32)
+        model = self._load_model()
+        embeddings = model.encode(list(texts), show_progress_bar=False, normalize_embeddings=True)
+        return np.asarray(embeddings, dtype=np.float32)
 
 
 def infer_topic_from_filename(filename: str) -> str:
     stem = Path(filename).stem
-    return stem.split("_")[0].capitalize()
+    parts = stem.split("_")
+    if parts:
+        return parts[0].capitalize()
+    return "Genel"
 
 
 def build_archive_path(source: Path, topic: str) -> Path:
     now = dt.datetime.now()
-    archive_root = settings.data_dir / "archive" / "by_topic" / topic / now.strftime("%Y-%m")
-    archive_root.mkdir(parents=True, exist_ok=True)
-    return archive_root / source.name
+    archive_dir = settings.archive_root / topic / now.strftime("%Y-%m")
+    return archive_dir / source.name
 
 
-def sha256_of_path(path: Path) -> str:
+def _sha256_of_path(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(8192), b""):
@@ -87,37 +138,109 @@ def sha256_of_path(path: Path) -> str:
 
 
 def extract_text(path: Path) -> str:
-    if path.suffix.lower() == ".pdf":
-        try:
-            import pypdf
-
-            reader = pypdf.PdfReader(str(path))
-            text = "\n".join(page.extract_text() or "" for page in reader.pages)
-            return text
-        except Exception as exc:  # pragma: no cover - fallback path
-            LOGGER.warning("PDF parsing failed for %s: %s", path, exc)
-            return ""
+    suffix = path.suffix.lower()
+    if suffix == ".pdf":
+        return _extract_pdf(path)
+    if suffix in {".docx"}:
+        return _extract_docx(path)
+    if suffix in {".ppt", ".pptx"}:
+        return _extract_pptx(path)
+    if suffix in {".png", ".jpg", ".jpeg", ".tiff"}:
+        return _extract_image(path)
     return path.read_text(encoding="utf-8", errors="ignore")
 
 
-def create_chunks(document: Document, text: str, session) -> List[Chunk]:
+def create_chunks(text: str, *, min_tokens: int = 800, max_tokens: int = 1200) -> List[str]:
     words = text.split()
-    chunk_size = 120
-    chunks: List[Chunk] = []
-    for idx in range(0, len(words), chunk_size):
-        chunk_text = " ".join(words[idx : idx + chunk_size])
-        chunk = Chunk(doc_id=document.id, seq=len(chunks), text=chunk_text, tokens=len(chunk_text.split()))
-        session.add(chunk)
-        session.flush()
-        session.refresh(chunk)
-        chunks.append(chunk)
-    if not chunks:
-        chunk = Chunk(doc_id=document.id, seq=0, text="", tokens=0)
-        session.add(chunk)
-        session.flush()
-        session.refresh(chunk)
-        chunks.append(chunk)
+    if not words:
+        return [""]
+    chunk_size = max(min_tokens, min(max_tokens, 900))
+    overlap = 100
+    chunks: List[str] = []
+    start = 0
+    while start < len(words):
+        end = min(len(words), start + chunk_size)
+        chunk_words = words[start:end]
+        chunks.append(" ".join(chunk_words))
+        if end == len(words):
+            break
+        start = end - overlap
     return chunks
+
+
+def _create_chunk_models(doc_id: int, texts: Sequence[str], embeddings: np.ndarray) -> List[Chunk]:
+    chunk_models: List[Chunk] = []
+    for idx, text in enumerate(texts):
+        embedding = embeddings[idx] if idx < len(embeddings) else np.zeros(384, dtype=np.float32)
+        chunk_models.append(
+            Chunk(
+                doc_id=doc_id,
+                seq=idx,
+                text=text,
+                embedding=embedding.tobytes(),
+                tokens=len(text.split()),
+            )
+        )
+    return chunk_models
+
+
+def _extract_pdf(path: Path) -> str:
+    try:
+        import pypdf
+
+        reader = pypdf.PdfReader(str(path))
+        return "\n".join(page.extract_text() or "" for page in reader.pages)
+    except Exception as exc:  # pragma: no cover - best effort
+        LOGGER.warning("PDF parse failed for %s: %s", path, exc)
+        return ""
+
+
+def _extract_docx(path: Path) -> str:
+    try:
+        import docx
+
+        document = docx.Document(str(path))
+        return "\n".join(paragraph.text for paragraph in document.paragraphs)
+    except Exception as exc:  # pragma: no cover - best effort
+        LOGGER.warning("DOCX parse failed for %s: %s", path, exc)
+        return ""
+
+
+def _extract_pptx(path: Path) -> str:
+    try:
+        from pptx import Presentation
+
+        presentation = Presentation(str(path))
+        lines: List[str] = []
+        for slide in presentation.slides:
+            for shape in slide.shapes:
+                if hasattr(shape, "text"):
+                    lines.append(shape.text)
+        return "\n".join(lines)
+    except Exception as exc:  # pragma: no cover - best effort
+        LOGGER.warning("PPTX parse failed for %s: %s", path, exc)
+        return ""
+
+
+def _extract_image(path: Path) -> str:
+    try:
+        from PIL import Image
+        import pytesseract
+
+        with Image.open(path) as image:
+            return pytesseract.image_to_string(image, lang="tur")
+    except Exception as exc:  # pragma: no cover - OCR optional
+        LOGGER.warning("OCR failed for %s: %s", path, exc)
+        return ""
+
+
+def generate_tags(text: str, limit: int = 5) -> List[str]:
+    words = [word.lower() for word in text.split() if len(word) > 4]
+    freq: dict[str, int] = {}
+    for word in words:
+        freq[word] = freq.get(word, 0) + 1
+    sorted_items = sorted(freq.items(), key=lambda item: item[1], reverse=True)
+    return [word for word, _ in sorted_items[:limit]]
 
 
 __all__ = [

--- a/mira_assistant/io/stt.py
+++ b/mira_assistant/io/stt.py
@@ -1,19 +1,67 @@
-"""Speech-to-text interface placeholder."""
+"""Speech-to-text utilities built on faster-whisper."""
 from __future__ import annotations
 
-from typing import Protocol
+import queue
+from typing import Optional
+
+import numpy as np
+
+class WhisperTranscriber:
+    """Offline STT wrapper using faster-whisper and WebRTC VAD."""
+
+    def __init__(self, model_size: str = "medium", device: str = "cpu") -> None:
+        from faster_whisper import WhisperModel  # type: ignore
+        import webrtcvad  # type: ignore
+
+        self.model = WhisperModel(model_size, device=device, compute_type="int8")
+        self.vad = webrtcvad.Vad(2)
+        self.samplerate = 16000
+        self.channels = 1
+
+    def listen_and_transcribe(self, silence_ms: int = 800) -> str:
+        import sounddevice as sd  # type: ignore
+
+        frame_duration = 30  # ms
+        frame_samples = int(self.samplerate * frame_duration / 1000)
+        audio_frames: list[bytes] = []
+        silence_frames_required = max(1, int(silence_ms / frame_duration))
+        silence_counter = 0
+        stream_queue: "queue.Queue[bytes]" = queue.Queue()
+
+        def callback(indata, frames, time, status):  # type: ignore[no-untyped-def]
+            if status:
+                pass
+            stream_queue.put(bytes(indata))
+
+        with sd.RawInputStream(
+            samplerate=self.samplerate,
+            blocksize=frame_samples,
+            dtype="int16",
+            channels=self.channels,
+            callback=callback,
+        ):
+            while True:
+                data = stream_queue.get()
+                if self.vad.is_speech(data, self.samplerate):
+                    audio_frames.append(data)
+                    silence_counter = 0
+                else:
+                    silence_counter += 1
+                if audio_frames and silence_counter >= silence_frames_required:
+                    break
+        if not audio_frames:
+            return ""
+        audio_bytes = b"".join(audio_frames)
+        return self._transcribe_bytes(audio_bytes)
+
+    def transcribe_file(self, path: str, *, language: Optional[str] = "tr") -> str:
+        segments, _ = self.model.transcribe(path, language=language, beam_size=1)
+        return " ".join(segment.text.strip() for segment in segments).strip()
+
+    def _transcribe_bytes(self, audio_bytes: bytes, *, language: Optional[str] = "tr") -> str:
+        audio_array = np.frombuffer(audio_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+        segments, _ = self.model.transcribe(audio_array, language=language, beam_size=1)
+        return " ".join(segment.text.strip() for segment in segments).strip()
 
 
-class SpeechToText(Protocol):
-    def transcribe(self, audio_path: str) -> str:
-        ...
-
-
-class MockSpeechToText:
-    """Mock implementation returning static text."""
-
-    def transcribe(self, audio_path: str) -> str:  # pragma: no cover - trivial
-        return f"TODO: Transcribe {audio_path}"
-
-
-__all__ = ["SpeechToText", "MockSpeechToText"]
+__all__ = ["WhisperTranscriber"]

--- a/mira_assistant/io/tts.py
+++ b/mira_assistant/io/tts.py
@@ -1,19 +1,81 @@
-"""Text-to-speech interface placeholder."""
+"""Text-to-speech helpers with edge-tts primary backend."""
 from __future__ import annotations
 
-from typing import Protocol
+import asyncio
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+LOGGER = logging.getLogger(__name__)
 
 
-class TextToSpeech(Protocol):
+class SpeechSynthesizer:
+    """Speak Turkish text using offline friendly backends."""
+
+    def __init__(self) -> None:
+        self._edge_voice = "tr-TR-ArdaNeural"
+        self._edge_communicate = None
+        self._pyttsx3_engine = None
+        try:
+            import edge_tts  # type: ignore
+
+            self._edge_communicate = edge_tts.Communicate
+        except Exception as exc:  # pragma: no cover - optional dependency
+            LOGGER.warning("edge-tts unavailable: %s", exc)
+            self._edge_communicate = None
+            self._ensure_pyttsx3()
+
     def speak(self, text: str) -> None:
-        ...
+        if not text.strip():
+            return
+        if self._edge_communicate is not None:
+            try:
+                asyncio.run(self._speak_edge(text))
+                return
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                loop.run_until_complete(self._speak_edge(text))
+                loop.close()
+            except Exception as exc:  # pragma: no cover - fallback path
+                LOGGER.error("edge-tts playback failed: %s", exc)
+        self._speak_pyttsx3(text)
+
+    async def _speak_edge(self, text: str) -> None:
+        from config import settings
+
+        communicator = self._edge_communicate(text, voice=self._edge_voice)
+        output = Path(settings.audio_dir) / f"tts-{int(time.time())}.mp3"
+        await communicator.save(str(output))
+        if os.name == "nt":  # pragma: no cover - windows only
+            try:
+                os.startfile(str(output))  # type: ignore[attr-defined]
+                return
+            except Exception as exc:
+                LOGGER.error("Windows playback failed: %s", exc)
+        self._speak_pyttsx3(text)
+
+    def _speak_pyttsx3(self, text: str) -> None:
+        engine = self._ensure_pyttsx3()
+        if engine is None:
+            LOGGER.error("pyttsx3 not available to speak: %s", text)
+            return
+        engine.say(text)
+        engine.runAndWait()
+
+    def _ensure_pyttsx3(self):  # type: ignore[no-untyped-def]
+        if self._pyttsx3_engine is None:
+            try:
+                import pyttsx3  # type: ignore
+
+                engine = pyttsx3.init()
+                engine.setProperty("voice", "tr")
+                self._pyttsx3_engine = engine
+            except Exception as exc:  # pragma: no cover - optional dependency
+                LOGGER.error("pyttsx3 initialisation failed: %s", exc)
+                self._pyttsx3_engine = None
+        return self._pyttsx3_engine
 
 
-class MockTextToSpeech:
-    """Mock implementation printing to stdout."""
-
-    def speak(self, text: str) -> None:  # pragma: no cover - trivial
-        print(f"[TTS] {text}")
-
-
-__all__ = ["TextToSpeech", "MockTextToSpeech"]
+__all__ = ["SpeechSynthesizer"]

--- a/mira_assistant/ui/main_window.py
+++ b/mira_assistant/ui/main_window.py
@@ -1,0 +1,265 @@
+"""PySide6 based desktop UI for Mira Assistant."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Qt, QThread, Signal, Slot
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from mira_assistant.core.actions import ActionDispatcher
+from mira_assistant.core.intent import Action, handle
+from mira_assistant.io.stt import WhisperTranscriber
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SpeechWorker(QThread):
+    """Background worker capturing speech input."""
+
+    transcribed = Signal(str)
+    failed = Signal(str)
+
+    def __init__(self, transcriber: WhisperTranscriber, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._transcriber = transcriber
+
+    def run(self) -> None:  # pragma: no cover - requires microphone
+        try:
+            text = self._transcriber.listen_and_transcribe()
+            if text:
+                self.transcribed.emit(text)
+        except Exception as exc:
+            self.failed.emit(str(exc))
+
+
+class MainWindow(QMainWindow):
+    """Main application window binding UI to the action dispatcher."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Mira Asistanı")
+        self.resize(960, 640)
+        self.dispatcher = ActionDispatcher()
+        self._transcriber: Optional[WhisperTranscriber] = None
+        self._speech_worker: Optional[SpeechWorker] = None
+        self._build_ui()
+        self.refresh_lists()
+
+    def _build_ui(self) -> None:
+        container = QWidget(self)
+        layout = QVBoxLayout(container)
+
+        command_row = QHBoxLayout()
+        self.command_input = QLineEdit()
+        self.command_input.setPlaceholderText("Komut yazın veya konuşun...")
+        self.command_input.returnPressed.connect(self._on_command_entered)
+        command_row.addWidget(self.command_input)
+
+        self.listen_button = QPushButton("Konuş")
+        self.listen_button.clicked.connect(self._toggle_listening)
+        command_row.addWidget(self.listen_button)
+
+        self.send_button = QPushButton("Gönder")
+        self.send_button.clicked.connect(self._on_command_entered)
+        command_row.addWidget(self.send_button)
+        layout.addLayout(command_row)
+
+        self.tabs = QTabWidget()
+        self._agenda_tab = self._build_agenda_tab()
+        self._tasks_tab = self._build_tasks_tab()
+        self._knowledge_tab = self._build_knowledge_tab()
+        self.tabs.addTab(self._agenda_tab, "Ajanda")
+        self.tabs.addTab(self._tasks_tab, "Görevler")
+        self.tabs.addTab(self._knowledge_tab, "Konu & Arşiv")
+        layout.addWidget(self.tabs)
+
+        self.status_label = QLabel("Hazır")
+        layout.addWidget(self.status_label)
+
+        container.setLayout(layout)
+        self.setCentralWidget(container)
+
+    def _build_agenda_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        self.event_list = QListWidget()
+        layout.addWidget(self.event_list)
+        refresh_btn = QPushButton("Ajandayı Yenile")
+        refresh_btn.clicked.connect(self.refresh_events)
+        layout.addWidget(refresh_btn)
+        return widget
+
+    def _build_tasks_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        self.task_list = QListWidget()
+        layout.addWidget(self.task_list)
+        refresh_btn = QPushButton("Görevleri Yenile")
+        refresh_btn.clicked.connect(self.refresh_tasks)
+        layout.addWidget(refresh_btn)
+        return widget
+
+    def _build_knowledge_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        self.topic_input = QLineEdit()
+        self.topic_input.setPlaceholderText("Konu")
+        layout.addWidget(self.topic_input)
+        ingest_row = QHBoxLayout()
+        ingest_btn = QPushButton("Inbox'u Tara")
+        ingest_btn.clicked.connect(self._ingest_inbox)
+        ingest_row.addWidget(ingest_btn)
+        file_btn = QPushButton("Dosya Seç")
+        file_btn.clicked.connect(self._ingest_file)
+        ingest_row.addWidget(file_btn)
+        layout.addLayout(ingest_row)
+
+        self.summary_view = QTextEdit()
+        self.summary_view.setReadOnly(True)
+        layout.addWidget(self.summary_view)
+
+        summarize_btn = QPushButton("Konu Özetle")
+        summarize_btn.clicked.connect(self._summarize_topic)
+        layout.addWidget(summarize_btn)
+        return widget
+
+    def _on_command_entered(self) -> None:
+        text = self.command_input.text().strip()
+        if not text:
+            return
+        action = handle(text)
+        if action is None:
+            self.status_label.setText("Komut anlaşılamadı.")
+            return
+        self._execute_action(action)
+        self.command_input.clear()
+
+    def _execute_action(self, action: Optional[Action]) -> None:
+        if action is None:
+            return
+        try:
+            result = self.dispatcher.run(action)
+            self.status_label.setText(f"{action.intent} işlendi.")
+            LOGGER.info("Action result: %s", result.data)
+        except Exception as exc:
+            LOGGER.exception("Komut çalıştırma hatası: %s", exc)
+            QMessageBox.critical(self, "Hata", str(exc))
+            return
+        self.refresh_lists()
+        if action.intent == "summarize_topic":
+            summary = result.data.get("summary", "")
+            self.summary_view.setPlainText(summary)
+
+    @Slot()
+    def refresh_lists(self) -> None:
+        self.refresh_events()
+        self.refresh_tasks()
+
+    @Slot()
+    def refresh_events(self) -> None:
+        action = Action(intent="list_events", payload={"range": "today"})
+        result = self.dispatcher.run(action)
+        self.event_list.clear()
+        for event in result.data.get("events", []):
+            start = event.get("start_dt", "")
+            title = event.get("title", "")
+            item = QListWidgetItem(f"{start} - {title}")
+            self.event_list.addItem(item)
+
+    @Slot()
+    def refresh_tasks(self) -> None:
+        action = Action(intent="list_tasks", payload={"include_completed": False})
+        result = self.dispatcher.run(action)
+        self.task_list.clear()
+        for task in result.data.get("tasks", []):
+            due = task.get("due_dt") or "-"
+            status = task.get("status")
+            title = task.get("title")
+            item = QListWidgetItem(f"[{status}] {title} (Son: {due})")
+            self.task_list.addItem(item)
+
+    @Slot()
+    def _toggle_listening(self) -> None:
+        if self._speech_worker and self._speech_worker.isRunning():
+            self._speech_worker.terminate()
+            self._speech_worker = None
+            self.status_label.setText("Dinleme durduruldu.")
+            return
+        if self._transcriber is None:
+            self._transcriber = WhisperTranscriber()
+        self._speech_worker = SpeechWorker(self._transcriber, self)
+        self._speech_worker.transcribed.connect(self._on_transcribed)
+        self._speech_worker.failed.connect(self._on_speech_failed)
+        self._speech_worker.start()
+        self.status_label.setText("Dinleniyor...")
+
+    @Slot(str)
+    def _on_transcribed(self, text: str) -> None:
+        self.status_label.setText(f"Algılanan komut: {text}")
+        action = handle(text)
+        self._execute_action(action)
+
+    @Slot(str)
+    def _on_speech_failed(self, error: str) -> None:
+        QMessageBox.warning(self, "STT Hatası", error)
+        self.status_label.setText("Dinleme başarısız.")
+
+    @Slot()
+    def _ingest_inbox(self) -> None:
+        topic = self.topic_input.text().strip() or None
+        action = Action(intent="ingest_docs", payload={"topic": topic})
+        result = self.dispatcher.run(action)
+        titles = ", ".join(result.data.get("ingested", []))
+        self.status_label.setText(f"Arşive alınan: {titles}" if titles else "Yeni belge yok.")
+
+    @Slot()
+    def _ingest_file(self) -> None:
+        file_path, _ = QFileDialog.getOpenFileName(self, "Belge Seç", str(Path.home()))
+        if not file_path:
+            return
+        topic = self.topic_input.text().strip() or None
+        try:
+            result = self.dispatcher.ingestor.ingest(Path(file_path), topic=topic)
+        except Exception as exc:
+            QMessageBox.critical(self, "İşleme hatası", str(exc))
+            return
+        self.status_label.setText(f"Belge işlendi: {result.document.title if result.document else '—'}")
+
+    @Slot()
+    def _summarize_topic(self) -> None:
+        topic = self.topic_input.text().strip()
+        if not topic:
+            QMessageBox.information(self, "Bilgi", "Özet için konu girin.")
+            return
+        action = Action(intent="summarize_topic", payload={"topic": topic})
+        result = self.dispatcher.run(action)
+        summary = result.data.get("summary", "")
+        self.summary_view.setPlainText(summary)
+
+    @Slot()
+    def quick_note(self) -> None:
+        text, accepted = QInputDialog.getText(self, "Hızlı Not", "Not içeriği:")
+        if not accepted or not text.strip():
+            return
+        action = Action(intent="add_task", payload={"title": text.strip()})
+        self._execute_action(action)
+
+
+__all__ = ["MainWindow"]

--- a/mira_assistant/ui/notifications.py
+++ b/mira_assistant/ui/notifications.py
@@ -1,0 +1,49 @@
+"""Desktop notifications and optional speech output."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from mira_assistant.io.tts import SpeechSynthesizer
+
+LOGGER = logging.getLogger(__name__)
+
+_try_toaster = None
+_synthesizer: Optional[SpeechSynthesizer] = None
+
+
+def _get_toaster():  # type: ignore[no-untyped-def]
+    global _try_toaster
+    if _try_toaster is not None:
+        return _try_toaster
+    try:
+        from win10toast import ToastNotifier  # type: ignore
+
+        _try_toaster = ToastNotifier()
+    except Exception as exc:  # pragma: no cover - optional dependency
+        LOGGER.warning("win10toast unavailable: %s", exc)
+        _try_toaster = False
+    return _try_toaster
+
+
+def show_toast(title: str, message: str, *, duration: int = 5, speak: bool = False) -> None:
+    toaster = _get_toaster()
+    if toaster:
+        try:
+            toaster.show_toast(title, message, duration=duration, threaded=True)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            LOGGER.error("Toast notification failed: %s", exc)
+    else:
+        LOGGER.info("Notification: %s - %s", title, message)
+    if speak:
+        _get_synthesizer().speak(message)
+
+
+def _get_synthesizer() -> SpeechSynthesizer:
+    global _synthesizer
+    if _synthesizer is None:
+        _synthesizer = SpeechSynthesizer()
+    return _synthesizer
+
+
+__all__ = ["show_toast"]

--- a/mira_assistant/ui/tray.py
+++ b/mira_assistant/ui/tray.py
@@ -1,24 +1,60 @@
-"""Placeholder for future tray UI implementation."""
+"""System tray integration using pystray."""
 from __future__ import annotations
 
 import threading
-from typing import Optional
+from typing import Callable, Optional
+
+import pystray
+from PIL import Image, ImageDraw
 
 
 class TrayController:
-    """Minimal stub for pystray based system tray icon."""
+    """Manage a pystray icon offering quick actions."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        on_toggle_listen: Callable[[], None],
+        on_show_agenda: Callable[[], None],
+        on_quick_note: Callable[[], None],
+        on_quit: Callable[[], None],
+    ) -> None:
+        self._on_toggle_listen = on_toggle_listen
+        self._on_show_agenda = on_show_agenda
+        self._on_quick_note = on_quick_note
+        self._on_quit = on_quit
+        self._icon: Optional[pystray.Icon] = None
         self._thread: Optional[threading.Thread] = None
 
-    def start(self) -> None:  # pragma: no cover - placeholder
+    def start(self) -> None:
         if self._thread and self._thread.is_alive():
             return
-        # TODO: Implement pystray integration.
+        self._icon = pystray.Icon("Mira", self._build_image(), "Mira Assistant", menu=self._build_menu())
+        self._thread = threading.Thread(target=self._icon.run, daemon=True)
+        self._thread.start()
 
-    def stop(self) -> None:  # pragma: no cover - placeholder
-        # TODO: Stop tray thread when implemented.
-        pass
+    def stop(self) -> None:
+        if self._icon:
+            self._icon.stop()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1)
+        self._icon = None
+        self._thread = None
+
+    def _build_menu(self) -> pystray.Menu:
+        return pystray.Menu(
+            pystray.MenuItem("Dinlemeyi Başlat/Durdur", lambda icon: self._on_toggle_listen()),
+            pystray.MenuItem("Bugünkü Ajanda", lambda icon: self._on_show_agenda()),
+            pystray.MenuItem("Hızlı Not", lambda icon: self._on_quick_note()),
+            pystray.MenuItem("Çıkış", lambda icon: self._on_quit()),
+        )
+
+    def _build_image(self) -> Image.Image:
+        image = Image.new("RGB", (64, 64), "#2d2d2d")
+        draw = ImageDraw.Draw(image)
+        draw.ellipse((8, 8, 56, 56), outline="#00bcd4", width=4)
+        draw.text((20, 22), "M", fill="#ffffff")
+        return image
 
 
 __all__ = ["TrayController"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,17 @@ sqlmodel==0.0.14
 typer==0.12.3
 uvicorn==0.29.0
 pytest==8.1.1
+faster-whisper==1.0.0
+sounddevice==0.4.6
+webrtcvad==2.0.10
+edge-tts==6.1.0
+pyttsx3==2.90
+pytesseract==0.3.10
+Pillow==10.3.0
+python-docx==1.1.0
+python-pptx==0.6.23
+sentence-transformers==2.7.0
+numpy==1.26.4
+PySide6==6.7.2
+pystray==0.19.5
+win10toast==0.9


### PR DESCRIPTION
## Summary
- Implement a PySide6 desktop shell with speech controls, agenda/task tabs, and knowledge ingest interactions tied to intent parsing.
- Introduce an action dispatcher, enhanced scheduler restore flow, and richer SQLModel schema to support reminders, summaries, and advisor warnings.
- Build offline ingestion, STT, and TTS helpers, add tray/notification plumbing, and refresh configuration plus README for the Windows-first setup.

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_b_68da7c0373e4832f9e7ea3797a89b534