### PR TITLE
Make Windows toast notifications optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ py -3.11 -m venv venv
 pip install -r requirements.txt
 ```
 
+Windows bildirimleri için isteğe bağlı olarak `win10toast` kütüphanesini ayrıca yükleyebilirsiniz. Bu bağımlılık artık kurulumun
+zorunlu bir parçası değildir; yüklenmediği durumda uygulama bildirim mesajlarını yalnızca günlük kayıtlarına yazar.
+
 OCR için sistemde Tesseract kurulumu gerekir:
 
 ```powershell

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,3 @@ sentence-transformers==2.7.0
 numpy==1.26.4
 PySide6==6.7.2
 pystray==0.19.5
-win10toast==0.9


### PR DESCRIPTION
## Summary
- drop the hard dependency on win10toast so pip installs do not fail on platforms without pywin32 wheels
- document that Windows toast notifications are now optional and fall back to logging when unavailable

## Testing
- pytest *(fails: existing test suite currently errors before exercising notification logic)*

------
https://chatgpt.com/codex/tasks/task_b_68da84f4eaa8832f96cbc5d3c6b883e5