### PR TITLE
Add PowerShell helper to isolate failing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ pip install -r requirements.txt
 Windows bildirimleri için isteğe bağlı olarak `win10toast` kütüphanesini ayrıca yükleyebilirsiniz. Bu bağımlılık artık kurulumun
 zorunlu bir parçası değildir; yüklenmediği durumda uygulama bildirim mesajlarını yalnızca günlük kayıtlarına yazar.
 
+Kurulum sırasında bir paket kaynaklı hata alırsanız `scripts/check_requirements.ps1` betiğiyle hangi bağımlılığın sorun çıkardığını
+tespit edebilirsiniz:
+
+```powershell
+pwsh ./scripts/check_requirements.ps1
+```
+
+Betik her bağımlılığı tek tek yükler; ilk hata aldığında durur ve paket adını kırmızı olarak bildirir. Hatanın ardındaki ayrıntı için
+eşlik eden `pip` çıktısını inceleyebilirsiniz. Gerekirse `-ContinueOnError` parametresiyle tüm bağımlılıkların kontrol edilmesini
+sağlayabilir veya `-VerbosePip` parametresiyle `pip` çıktısını ayrıntılandırabilirsiniz.
+
 OCR için sistemde Tesseract kurulumu gerekir:
 
 ```powershell

--- a/scripts/check_requirements.ps1
+++ b/scripts/check_requirements.ps1
@@ -1,0 +1,75 @@
+param(
+    [string]$RequirementsPath = (Join-Path $PSScriptRoot '..' 'requirements.txt'),
+    [switch]$VerbosePip,
+    [switch]$ContinueOnError
+)
+
+if (-not (Test-Path $RequirementsPath)) {
+    Write-Error "Girdi dosyası bulunamadı: $RequirementsPath"
+    exit 1
+}
+
+$rawLines = Get-Content $RequirementsPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+$dependencies = @()
+foreach ($line in $rawLines) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed.StartsWith('#')) {
+        $dependencies += $trimmed
+    }
+}
+
+if ($dependencies.Count -eq 0) {
+    Write-Warning 'requirements.txt dosyasında işlenecek bağımlılık bulunamadı.'
+    return
+}
+
+$python = Get-Command py -ErrorAction SilentlyContinue
+if ($python) {
+    $pythonExe = 'py'
+    $pythonArgs = @('-3.11')
+} else {
+    $pythonExe = 'python'
+    $pythonArgs = @()
+}
+
+Write-Host "Toplam $($dependencies.Count) bağımlılık kontrol edilecek." -ForegroundColor Cyan
+Write-Host 'Her bağımlılık ayrı ayrı yüklenerek hangi paketin hata verdiği tespit edilmeye çalışılacak.' -ForegroundColor Cyan
+Write-Host ''
+
+$failures = @()
+for ($i = 0; $i -lt $dependencies.Count; $i++) {
+    $package = $dependencies[$i]
+    $header = "[$($i + 1)/$($dependencies.Count)] $package"
+    Write-Host $header -ForegroundColor Yellow
+
+    $args = $pythonArgs + @('-m', 'pip', 'install', '--disable-pip-version-check', '--no-input', $package)
+    if ($VerbosePip) {
+        $args += '--verbose'
+    }
+
+    & $pythonExe @args
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
+        Write-Host '  -> Başarılı' -ForegroundColor Green
+    } else {
+        Write-Host "  -> Hata (çıkış kodu $exitCode)" -ForegroundColor Red
+        $failures += [PSCustomObject]@{ Paket = $package; Kod = $exitCode }
+        if (-not $ContinueOnError) {
+            break
+        }
+    }
+
+    Write-Host ''
+}
+
+if ($failures.Count -eq 0) {
+    Write-Host 'Tüm bağımlılıklar sorunsuz işlendi.' -ForegroundColor Green
+} else {
+    Write-Host 'Hata veren bağımlılıklar:' -ForegroundColor Red
+    foreach ($failure in $failures) {
+        Write-Host "  - $($failure.Paket) (çıkış kodu $($failure.Kod))" -ForegroundColor Red
+    }
+    Write-Host ''
+    Write-Host 'Detaylı günlük için hata veren paketin hemen üstündeki pip çıktısına bakabilirsiniz.'
+}


### PR DESCRIPTION
## Summary
- add a PowerShell script that installs each requirement individually to show the package that fails
- document the helper script in the README with usage examples and optional flags

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68da868b0e1c832facd28ad0c5054cbb