### PR TITLE
Update Pillow dependency for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ webrtcvad==2.0.10
 edge-tts==6.1.0
 pyttsx3==2.90
 pytesseract==0.3.10
-Pillow==10.3.0
+Pillow==11.3.0
 python-docx==1.1.0
 python-pptx==0.6.23
 sentence-transformers==2.7.0


### PR DESCRIPTION
## Summary
- bump the Pillow dependency to version 11.3.0 to ensure compatibility with Python 3.13

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68da895b4398832fb43baafc214280e3