### PR TITLE
Relax PySide6 requirement for Python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ python-docx==1.1.0
 python-pptx==0.6.23
 sentence-transformers==2.7.0
 numpy==1.26.4
-PySide6==6.7.2
+PySide6>=6.8.0
 pystray==0.19.5


### PR DESCRIPTION
## Summary
- raise the minimum PySide6 version to 6.8.0 so it can be installed on Python 3.12 environments

## Testing
- pytest *(fails: missing optional dependency `sqlmodel` in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68da8af16f38832f96fbce841791007b