### PR TITLE
Document Python version support and guard runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ py -3.11 -m venv venv
 pip install -r requirements.txt
 ```
 
+> [!IMPORTANT]
+> Python 3.13 henüz desteklenmiyor. Bazı yerel bağımlılıklar (örn. PyAV) bu sürüm için tekerlek
+> yayınlamadığından `pip install` sürecinde derleme hataları oluşur. Python 3.11 veya 3.12 kullanın.
+
 Windows bildirimleri için isteğe bağlı olarak `win10toast` kütüphanesini ayrıca yükleyebilirsiniz. Bu bağımlılık artık kurulumun
 zorunlu bir parçası değildir; yüklenmediği durumda uygulama bildirim mesajlarını yalnızca günlük kayıtlarına yazar.
 

--- a/app.py
+++ b/app.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+if sys.version_info >= (3, 13):  # pragma: no cover - defensive runtime guard
+    raise RuntimeError(
+        "Mira Assistant currently supports Python < 3.13. "
+        "Some native dependencies (PyAV) do not yet provide wheels for Python 3.13."
+    )
 
 import typer
 from rich.console import Console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Offline-first personal assistant for Windows"
 readme = "README.md"
 authors = [{name = "Murat", email = "murat@example.com"}]
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 dependencies = [
   "apscheduler",
   "chromadb",


### PR DESCRIPTION
## Summary
- restrict the published metadata to Python 3.11/3.12 while PyAV wheels catch up
- raise a runtime error early if the CLI is launched under Python 3.13+
- document the Python version requirement in the installation instructions

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_b_68da8e8343fc832faca057c5fd7ad62c