### PR TITLE
Cancel scheduled reminders when events are modified or removed

### DIFF
--- a/mira_assistant/core/actions.py
+++ b/mira_assistant/core/actions.py
@@ -90,6 +90,7 @@ class ActionDispatcher:
             session.add(event)
             session.commit()
             session.refresh(event)
+        self.scheduler.cancel_event_reminders(event_id)
         self.scheduler.schedule_event_reminders(event, event.remind_policy)
         if hasattr(event, "model_dump"):
             payload = event.model_dump()  # type: ignore[attr-defined]
@@ -101,6 +102,8 @@ class ActionDispatcher:
         event_id = int(payload.get("event_id", 0))
         with get_session() as session:
             deleted = delete_event(session, event_id)
+        if deleted:
+            self.scheduler.cancel_event_reminders(event_id)
         return {"deleted": deleted}
 
     def handle_list_events(self, payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/mira_assistant/core/summarizer.py
+++ b/mira_assistant/core/summarizer.py
@@ -34,6 +34,12 @@ def generate_summary(topic: str, chunks: Sequence[str], meeting_notes: Sequence[
     return "\n".join(line.rstrip() for line in summary.splitlines())
 
 
+def summarise_topic(chunks: Sequence[str], topic: str = "Genel", meeting_notes: Sequence[str] | None = None) -> str:
+    """Backward compatible wrapper returning a summary for a topic."""
+
+    return generate_summary(topic, chunks, meeting_notes)
+
+
 def _collect_sentences(texts: Iterable[str], *, limit: int) -> List[str]:
     sentences: List[str] = []
     for text in texts:
@@ -68,4 +74,4 @@ def _infer_risks(sentences: Sequence[str]) -> List[str]:
     return risks
 
 
-__all__ = ["generate_summary"]
+__all__ = ["generate_summary", "summarise_topic"]


### PR DESCRIPTION
## Summary
- add a helper on the reminder scheduler to remove all jobs tied to an event id
- clear reminder jobs when events are updated or deleted so rescheduling uses the latest policy
- restore the summariser API compatibility and cover reminder cleanup with an acceptance test

## Testing
- `pytest` *(fails: huggingface.co is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dcd88f902c832f95f30b9eff1f3ed2