### PR TITLE
Include upcoming events in agenda view

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -59,6 +59,24 @@ def test_speech_style_event_command_is_listed():
     assert any(event["id"] == result.data["event_id"] for event in events)
 
 
+def test_upcoming_range_lists_future_events():
+    dispatcher_module = __import__("mira_assistant.core.actions", fromlist=["ActionDispatcher"])
+    intent_module = __import__("mira_assistant.core.intent", fromlist=["Action"])
+    dispatcher = dispatcher_module.ActionDispatcher()
+
+    far_future = dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=21)
+    add_action = intent_module.Action(
+        intent="add_event", payload={"title": "Uzak toplantı", "start": far_future.isoformat()}
+    )
+    result = dispatcher.run(add_action)
+    assert result.data["event_id"] is not None
+
+    upcoming_action = intent_module.Action(intent="list_events", payload={"range": "upcoming"})
+    events = dispatcher.run(upcoming_action).data["events"]
+
+    assert any(event["id"] == result.data["event_id"] for event in events)
+
+
 def test_ingest_document_moves_and_summarises(tmp_path):
     get_app()  # ensure directories initialised
     ingestor_module = __import__("mira_assistant.io.ingest", fromlist=["DocumentIngestor"])


### PR DESCRIPTION
## Summary
- teach `handle_list_events` to honour range hints (today, upcoming, month, etc.) so callers can request broader windows
- load upcoming events in the Qt UI and keep the weekly summary accurate by filtering within the next seven days
- add an acceptance test that verifies "upcoming" includes far-future events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd03470cac832fabbca263c9a39077