### PR TITLE
Ensure data directory exists within project structure

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,8 +2,10 @@
 
 This module centralises directory paths, timezone configuration and model
 selection so that the rest of the codebase can rely on a single source of
-truth.  Values are read from the environment when available but sensible
-defaults matching the product brief are provided.
+truth. Values are read from the environment when available but sensible
+defaults matching the product brief are provided.  The defaults now place
+the data directory inside the project tree to ensure that local development
+environments always create the expected ``data/`` folder.
 """
 from __future__ import annotations
 
@@ -15,11 +17,12 @@ from typing import Iterable, List
 from zoneinfo import ZoneInfo
 
 
+BASE_DIR = Path(__file__).parent
 DEFAULT_REMINDERS = [1440, 60, 10]
-DEFAULT_DATA_DIR = "~/MiraData"
+DEFAULT_DATA_DIR = BASE_DIR / "data"
 DEFAULT_TIMEZONE = "Europe/Istanbul"
 DEFAULT_EMBED_MODEL = "paraphrase-multilingual-MiniLM-L12-v2"
-DEFAULT_CHROMA_PATH = "~/MiraData/index"
+DEFAULT_CHROMA_PATH = DEFAULT_DATA_DIR / "index"
 
 
 def _load_int_list(value: str | None, fallback: Iterable[int]) -> List[int]:
@@ -45,14 +48,14 @@ def _bool_env(name: str, default: bool) -> bool:
 class Settings:
     """Runtime settings resolved from the environment."""
 
-    data_dir: Path = Path(os.getenv("MIRA_DATA_DIR", DEFAULT_DATA_DIR)).expanduser()
+    data_dir: Path = Path(os.getenv("MIRA_DATA_DIR", str(DEFAULT_DATA_DIR))).expanduser()
     timezone_name: str = os.getenv("MIRA_TZ", DEFAULT_TIMEZONE)
     offline_only: bool = _bool_env("MIRA_OFFLINE_ONLY", True)
     default_reminders: List[int] = field(
         default_factory=lambda: _load_int_list(os.getenv("MIRA_REMINDERS"), DEFAULT_REMINDERS)
     )
     embed_model_name: str = os.getenv("MIRA_EMBED_MODEL", DEFAULT_EMBED_MODEL)
-    chroma_path: Path = Path(os.getenv("MIRA_CHROMA_PATH", DEFAULT_CHROMA_PATH)).expanduser()
+    chroma_path: Path = Path(os.getenv("MIRA_CHROMA_PATH", str(DEFAULT_CHROMA_PATH))).expanduser()
 
     def ensure_directories(self) -> None:
         """Create all folders required by the assistant if they do not exist."""

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,46 @@
+"""Compatibility wrapper around the core storage module.
+
+The original project structure exposed a top-level ``storage`` module.  This
+file keeps that import path available while delegating all functionality to
+``mira_assistant.core.storage``.  Keeping the thin wrapper avoids breaking
+downstream tooling while ensuring the shared configuration is still honoured.
+"""
+from mira_assistant.core.storage import (  # noqa: F401
+    Chunk,
+    Document,
+    Event,
+    Knowledge,
+    Meeting,
+    Note,
+    Task,
+    TaskStatus,
+    add_event,
+    add_note,
+    complete_task,
+    delete_event,
+    get_engine,
+    get_session,
+    init_db,
+    list_events_between,
+    upsert_task,
+)
+
+__all__ = [
+    "Chunk",
+    "Document",
+    "Event",
+    "Knowledge",
+    "Meeting",
+    "Note",
+    "Task",
+    "TaskStatus",
+    "add_event",
+    "add_note",
+    "complete_task",
+    "delete_event",
+    "get_engine",
+    "get_session",
+    "init_db",
+    "list_events_between",
+    "upsert_task",
+]


### PR DESCRIPTION
## Summary
- default the Mira Assistant data directory to the repository's local `data/` folder and keep creating all required subdirectories
- add a compatibility wrapper so the legacy `storage` module import path still works

## Testing
- python -c "from storage import init_db; init_db()"
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ddc21058d0832f8e06dd91f29da93f