### PR TITLE
Improve Turkish datetime parsing for suffixed hour phrases

### DIFF
--- a/mira_assistant/core/parser_tr.py
+++ b/mira_assistant/core/parser_tr.py
@@ -19,7 +19,13 @@ DEFAULT_SETTINGS = {
     "PARSERS": ["relative-time", "custom-formats", "absolute-time"],
 }
 
-_TIME_PATTERN = re.compile(r"(\d{1,2}[:. ]\d{2})|(saat\s*\d{1,2})", re.IGNORECASE)
+_TIME_PATTERN = re.compile(
+    r"(?:\d{1,2}[:. ]\d{2})|"  # 14:00, 14.00, 14 00
+    r"(?:saat\s+\d{1,2}(?:\s*(?:da|de|te)\b)?)|"  # saat 14, saat 14 te
+    r"(?:\d{1,2}\s+(?:da|de|te)\b)",  # 14 da, 14 de, 14 te
+    re.IGNORECASE,
+)
+_DAY_SUFFIX_PATTERN = re.compile(r"\b(\d{1,2})\s*(?:si|sı|inci|ıncı|uncu|üncü|ncı|nci)\b", re.IGNORECASE)
 _APOSTROPHE_PATTERN = re.compile(r"(\d+)'([a-zçğıöşü]+)", re.IGNORECASE)
 
 
@@ -43,22 +49,63 @@ def parse_datetime(
 
     normalised = _normalise_text(text)
 
+    time_match = _TIME_PATTERN.search(normalised)
+    extracted_hour = None
+    if time_match:
+        match_text = time_match.group(0)
+        hour_match = re.fullmatch(r"saat\s+(\d{1,2})(?:\s*(?:da|de|te)\b)?", match_text, re.IGNORECASE)
+        if not hour_match:
+            hour_match = re.fullmatch(r"(\d{1,2})\s+(?:da|de|te)\b", match_text, re.IGNORECASE)
+        if hour_match:
+            try:
+                extracted_hour = int(hour_match.group(1))
+                if not 0 <= extracted_hour <= 23:
+                    extracted_hour = None
+            except (TypeError, ValueError):
+                extracted_hour = None
+
+    date_candidates = []
+    if normalised:
+        date_candidates.append(normalised)
+    if time_match:
+        pre_text = normalised[: time_match.start()].strip()
+        post_text = normalised[time_match.end() :].strip()
+        stripped = (pre_text + " " + post_text).strip()
+        for candidate in (pre_text, stripped, post_text):
+            if candidate and candidate not in date_candidates:
+                date_candidates.append(candidate)
+    day_suffix_match = _DAY_SUFFIX_PATTERN.search(normalised)
+
     settings_dict = DEFAULT_SETTINGS.copy()
     if reference is not None:
         settings_dict["RELATIVE_BASE"] = reference
-    parsed = dateparser.parse(normalised, languages=["tr"], settings=settings_dict)
+    parsed: Optional[dt.datetime] = None
+    for candidate in date_candidates:
+        parsed = dateparser.parse(candidate, languages=["tr"], settings=settings_dict)
+        if isinstance(parsed, dt.datetime):
+            break
     if not isinstance(parsed, dt.datetime):
         # dateparser struggles with longer natural language phrases such as
         # "yarın saat 10'da toplantı var" and returns ``None``. When this
         # happens we fallback to ``search_dates`` which scans the string for
         # fragments that look like a datetime expression. The first match is
         # used as the parsed value.
-        matches = search_dates(normalised, languages=["tr"], settings=settings_dict) or []
-        if matches:
-            parsed = matches[0][1]
-        else:
+        for candidate in date_candidates:
+            matches = search_dates(candidate, languages=["tr"], settings=settings_dict) or []
+            if matches:
+                parsed = matches[0][1]
+                break
+        if not isinstance(parsed, dt.datetime):
             return None
-    if default_hour is not None and not _has_explicit_time(text):
+    if day_suffix_match:
+        try:
+            parsed = parsed.replace(day=int(day_suffix_match.group(1)))
+        except ValueError:
+            pass
+
+    if extracted_hour is not None:
+        parsed = parsed.replace(hour=extracted_hour, minute=default_minute, second=0, microsecond=0)
+    elif default_hour is not None and not _has_explicit_time(text):
         parsed = parsed.replace(hour=default_hour, minute=default_minute, second=0, microsecond=0)
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=settings.timezone)
@@ -74,7 +121,7 @@ def to_utc(value: dt.datetime) -> dt.datetime:
 
 
 def _has_explicit_time(text: str) -> bool:
-    return bool(_TIME_PATTERN.search(text))
+    return bool(_TIME_PATTERN.search(_normalise_text(text)))
 
 
 __all__ = ["parse_datetime", "to_utc"]

--- a/tests/test_parser_tr.py
+++ b/tests/test_parser_tr.py
@@ -1,0 +1,35 @@
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+IST = ZoneInfo("Europe/Istanbul")
+
+
+@pytest.mark.parametrize(
+    "phrase, expected",
+    [
+        ("Yarın saat 14 te tedarikçi toplantısı", dt.datetime(2025, 10, 3, 14, 0, tzinfo=IST)),
+        ("Bugün 16 da rapor teslimi", dt.datetime(2025, 10, 2, 16, 0, tzinfo=IST)),
+        ("Pazartesi 9 da kahvaltı", dt.datetime(2025, 10, 6, 9, 0, tzinfo=IST)),
+    ],
+)
+def test_turkish_hour_suffixes_are_parsed(phrase: str, expected: dt.datetime) -> None:
+    reference = dt.datetime(2025, 10, 2, 9, 0, tzinfo=IST)
+    parser_tr = __import__("mira_assistant.core.parser_tr", fromlist=["parse_datetime"])
+
+    parsed = parser_tr.parse_datetime(phrase, reference=reference)
+
+    assert parsed == expected
+
+
+def test_time_detection_handles_apostrophes() -> None:
+    reference = dt.datetime(2025, 10, 2, 9, 0, tzinfo=IST)
+    parser_tr = __import__("mira_assistant.core.parser_tr", fromlist=["parse_datetime"])
+
+    parsed = parser_tr.parse_datetime("22'si saat 10:00'da tedarikçi", reference=reference)
+
+    assert parsed.hour == 10
+    assert parsed.minute == 0
+    assert parsed.day == 22


### PR DESCRIPTION
## Summary
- expand the Turkish time detection regex to cover suffix variants and apostrophe-normalised input
- add heuristics that recover date components when dateparser cannot parse full Turkish phrases
- add regression tests for suffixed hour expressions and apostrophe-based commands

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ddc8685a34832f9eeae970f134a863