### PR TITLE
Load configuration from dotenv file

### DIFF
--- a/.envexample
+++ b/.envexample
@@ -1,0 +1,9 @@
+# Example environment configuration for Mira Assistant
+# Copy this file to `.env` and adjust the values for your setup.
+
+# OpenAI API configuration
+OPENAI_API_KEY=sk-your-openai-api-key
+MIRA_LLM_MODEL=gpt-4o-mini
+
+# Optional: set to a different .env path and export MIRA_ENV_FILE
+# MIRA_ENV_FILE=/absolute/path/to/.env

--- a/config.py
+++ b/config.py
@@ -16,8 +16,28 @@ from pathlib import Path
 from typing import Iterable, List
 from zoneinfo import ZoneInfo
 
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency guard
+    load_dotenv = None
+
 
 BASE_DIR = Path(__file__).parent
+
+if load_dotenv:  # pragma: no branch - simple configuration loader
+    candidate_paths = []
+    if env_file := os.environ.get("MIRA_ENV_FILE"):
+        candidate_paths.append(Path(env_file).expanduser())
+    candidate_paths.append(BASE_DIR / ".env")
+    candidate_paths.append(BASE_DIR.parent / ".env")
+    loaded = False
+    for env_path in candidate_paths:
+        if env_path and env_path.exists():
+            load_dotenv(env_path, override=False)
+            loaded = True
+            break
+    if not loaded:
+        load_dotenv(override=False)
 DEFAULT_REMINDERS = [1440, 60, 10]
 DEFAULT_DATA_DIR = BASE_DIR / "data"
 DEFAULT_TIMEZONE = "Europe/Istanbul"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "dateparser",
   "fastapi",
   "pypdf",
+  "python-dotenv",
   "rich",
   "sqlmodel",
   "typer",


### PR DESCRIPTION
## Summary
- load environment variables from a project-level .env file before building settings
- document required keys in a new .envexample template for API key and model selection
- declare python-dotenv as an application dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ddd69b523c832f8f747859fff96766