### PR TITLE
Fix action payload handling and prevent Unicode logging errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,17 +67,22 @@ class AssistantService:
 
     def handle_add_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         self.start_scheduler()
-        start_str = payload.get("start")
+        start_str = (
+            payload.get("start")
+            or payload.get("date_time")
+            or payload.get("start_dt")
+            or payload.get("datetime")
+        )
         if not start_str:
             raise ValueError("Event start time missing")
         start_dt = dt.datetime.fromisoformat(start_str)
         if start_dt.tzinfo is None:
             start_dt = start_dt.replace(tzinfo=dt.timezone.utc)
         event = Event(
-            title=payload.get("title", "Etkinlik"),
+            title=payload.get("title") or payload.get("event") or payload.get("name") or "Etkinlik",
             start_dt=start_dt,
             end_dt=payload.get("end_dt"),
-            location=payload.get("location"),
+            location=payload.get("location") or payload.get("place"),
             remind_policy=payload.get("remind_policy"),
             notes=payload.get("notes"),
         )
@@ -99,11 +104,16 @@ class AssistantService:
         return {"task_id": task.id}
 
     def handle_note(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        text = str(payload.get("text") or "").strip()
+        text = str(
+            payload.get("text")
+            or payload.get("message")
+            or payload.get("content")
+            or ""
+        ).strip()
         if not text:
             return {"saved": False, "note_id": None}
 
-        title = payload.get("title")
+        title = payload.get("title") or payload.get("subject")
         if not title:
             first_line = text.splitlines()[0].strip()
             title = first_line or "Not"

--- a/app_ui.py
+++ b/app_ui.py
@@ -13,10 +13,23 @@ from mira_assistant.core.storage import Event, get_session, init_db
 from mira_assistant.ui.main_window import MainWindow
 from mira_assistant.ui.tray import TrayController
 
+if hasattr(sys.stdout, "reconfigure"):
+    # Ensure console logging never crashes on characters that the active code
+    # page cannot represent (e.g. combining Turkish dotted i variants).
+    try:
+        sys.stdout.reconfigure(errors="replace")
+    except TypeError:
+        # Some platforms expose ``reconfigure`` but do not accept the ``errors``
+        # keyword – ignore silently and keep the default behaviour.
+        pass
+
+stream_handler = logging.StreamHandler(sys.stdout)
+file_handler = logging.FileHandler(str(settings.log_dir / "mira.log"), encoding="utf-8")
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
-    handlers=[logging.FileHandler(str(settings.log_dir / "mira.log")), logging.StreamHandler(sys.stdout)],
+    handlers=[file_handler, stream_handler],
 )
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- accept alternate event payload fields produced by recent LLM responses so events use the correct title and start time
- relax note handling to save content provided under legacy keys
- harden UI logging configuration to avoid Windows console Unicode encoding failures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ddddb0d428832faa7770652e9dc8f9