### PR TITLE
Fix note action payload handling

### DIFF
--- a/mira_assistant/core/actions.py
+++ b/mira_assistant/core/actions.py
@@ -154,6 +154,7 @@ class ActionDispatcher:
             payload.get("text")
             or payload.get("message")
             or payload.get("content")
+            or payload.get("note")
             or ""
         ).strip()
         if not text:


### PR DESCRIPTION
## Summary
- ensure the note action reads the `note` payload field so free-form notes are saved

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dddeeb8874832f9be697550e3012da