### PR TITLE
Reduce task refresh frequency and fix LLM prompt placeholders

### DIFF
--- a/mira_assistant/core/llm_intent.py
+++ b/mira_assistant/core/llm_intent.py
@@ -112,12 +112,13 @@ def _get_client() -> OpenAI:
 
 
 def _system_prompt() -> str:
-    today = dt.datetime.now(settings.timezone).strftime("%Y-%m-%d")
-    return (
-        SYSTEM_PROMPT
-        + f"Bugün: {today}\n"
-        + "Her zaman geçerli JSON döndür. Ek açıklama yazma."
+    now = dt.datetime.now(settings.timezone)
+    today = now.strftime("%Y-%m-%d")
+    tomorrow = (now + dt.timedelta(days=1)).strftime("%Y-%m-%d")
+    prompt = (
+        SYSTEM_PROMPT.replace("{today}", today).replace("{tomorrow}", tomorrow)
     )
+    return prompt + f"Bugün: {today}\nHer zaman geçerli JSON döndür. Ek açıklama yazma."
 
 
 def handle_with_llm(text: str) -> Optional["Action"]:


### PR DESCRIPTION
## Summary
- add a debounced task refresh timer in the main window to avoid repeatedly calling the `list_tasks` intent while keeping user-triggered updates responsive
- ensure the LLM system prompt replaces `{today}` and `{tomorrow}` placeholders with the current and next day values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68de743db588832fb1f277d3e5c290e6